### PR TITLE
Remove typescript from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,5 @@
     "tslib": "^1.10.0",
     "typedoc": "^0.15.0",
     "typescript": "^3.5.3"
-  },
-  "peerDependencies": {
-    "typescript": "^3.5.0"
   }
 }


### PR DESCRIPTION
Imagine:
* Person A, a TypeScript user, uses `ts-toolbelt` for their types.
* Person B, a pure JavaScript user, only wish to install person A's package without TypeScript, they must give must give up `--strict-peer-dependecies` flag.

I don't want packages that use `ts-toolbelt` come with such limitation.
