### PR TITLE
Fix O.P.Pick to distribute over unions

### DIFF
--- a/src/Object/P/Merge.ts
+++ b/src/Object/P/Merge.ts
@@ -11,11 +11,16 @@ import {Depth} from '../_Internal'
 import {Tuple} from '../../Tuple/Tuple'
 
 type _Merge<O extends object, Path extends Tuple<Index>, O1 extends object, depth extends Depth, I extends Iteration = IterationOf<'0'>> = {
-  [K in keyof O]: K extends Path[Pos<I>]                          // If K is part of Path
-                  ? Pos<I> extends EndOf<Path>                    // & if it's the target
-                    ? OMerge<O[K] & {}, O1, depth> // merge it    // Update - target
-                    : _Merge<O[K] & {}, Path, O1, depth, Next<I>> // Or continue diving
-                  : O[K]                                          // Not part of path - x
+  [K in keyof O]:
+    O[K] extends infer Prop                        // Needed for the below to be distributive
+    ? K extends Path[Pos<I>]                       // If K is part of Path
+      ? Prop extends object                        // & if it's an object
+        ? Pos<I> extends EndOf<Path>               // & if it's the target
+          ? OMerge<Prop, O1, depth> // merge it    // Update - target
+          : _Merge<Prop, Path, O1, depth, Next<I>> // Or continue diving
+        : Prop                                     // Part of path, but not object - x
+      : Prop                                       // Not part of path - x
+    : never
 } & {}
 
 /** Complete the fields of **`O`** at **`Path`** with the ones of **`O1`**

--- a/src/Object/P/Omit.ts
+++ b/src/Object/P/Omit.ts
@@ -13,11 +13,16 @@ import {Tuple} from '../../Tuple/Tuple'
 type Never = Type<{}, 'never'>
 
 type _Omit<O extends object, Path extends Tuple<Index>, I extends Iteration = IterationOf<'0'>> = {
-    [K in keyof O]: K extends Path[Pos<I>]              // If K is part of Path
-                    ? Pos<I> extends EndOf<Path>        // & if it's the target
-                      ? Never // don't pick             // Update - target
-                      : _Omit<O[K] & {}, Path, Next<I>> // Or continue diving
-                    : O[K] // pick it                  // Not part of path - x
+  [K in keyof O]:
+    O[K] extends infer Prop               // Needed for the below to be distributive
+    ? K extends Path[Pos<I>]              // If K is part of Path
+      ? Pos<I> extends EndOf<Path>        // & if it's the target
+        ? Never // don't pick             // Update - target
+        : Prop extends object             // If it's an object
+          ? _Omit<Prop, Path, Next<I>>    // Continue diving
+          : Prop // pick it               // Part of path, but not object - x
+      : Prop // pick it                   // Not part of path - x
+    : never
 } & {} extends infer X ? Filter<X & {}, Never, '<-extends'> : never // No `never` fields
 
 /** Remove out of **`O`** the fields at **`Path`**

--- a/src/Object/P/Pick.ts
+++ b/src/Object/P/Pick.ts
@@ -2,7 +2,6 @@ import {IterationOf} from '../../Iteration/IterationOf'
 import {Iteration} from '../../Iteration/Iteration'
 import {Pos} from '../../Iteration/Pos'
 import {Next} from '../../Iteration/Next'
-import {NonNullable} from '../../Union/NonNullable'
 import {Path as PPath} from './_Internal'
 import {Index} from '../../Any/Index'
 import {Pick as OPick} from '../Pick'
@@ -10,13 +9,16 @@ import {EndOf} from '../../Tuple/EndOf'
 import {Tuple} from '../../Tuple/Tuple'
 
 type _Pick<O extends object, Path extends Tuple<Index>, I extends Iteration = IterationOf<'0'>> =
-  OPick<O, Path[Pos<I>]> extends infer Picked                      // Pick the first Path
+  OPick<O, Path[Pos<I>]> extends infer Picked // Pick the first Path
   ? {
-      [K in keyof Picked]: NonNullable<Picked[K]> extends object   // > If it's an object
-                          ? Pos<I> extends EndOf<Path>             // & If it's the target
-                            ? Picked[K]                            // 1-1: Pick it
-                            : _Pick<Picked[K] & {}, Path, Next<I>> // 1-0: Continue diving
-                          : Picked[K]                              // 0: Pick property
+      [K in keyof Picked]:
+        Picked[K] extends infer Prop          // Needed for the below to be distributive
+        ? Prop extends object                 // > If it's an object
+          ? Pos<I> extends EndOf<Path>        // & If it's the target
+            ? Prop                            // 1-1: Pick it
+            : _Pick<Prop, Path, Next<I>>      // 1-0: Continue diving
+          : Prop                              // 0: Pick property
+        : never
     }
   : never
 

--- a/src/Object/P/Update.ts
+++ b/src/Object/P/Update.ts
@@ -9,11 +9,16 @@ import {EndOf} from '../../Tuple/EndOf'
 import {Tuple} from '../../Tuple/Tuple'
 
 type _Update<O extends object, Path extends Tuple<Index>, A, I extends Iteration = IterationOf<'0'>> = {
-  [K in keyof O]: K extends Path[Pos<I>]                   // If K is part of Path
-                  ? Pos<I> extends EndOf<Path>             // & if it's the target
-                    ? A // update it                       // Update - target
-                    : _Update<O[K] & {}, Path, A, Next<I>> // Or continue diving
-                  : O[K] // don't update                  // Not part of path - x
+  [K in keyof O]:
+    O[K] extends infer Prop                 // Needed for the below to be distributive
+    ? K extends Path[Pos<I>]                // If K is part of Path
+      ? Pos<I> extends EndOf<Path>          // & if it's the target
+        ? A // update it                    // Update - target
+        : Prop extends object               // If prop is an object
+          ? _Update<Prop, Path, A, Next<I>> // Continue diving
+          : Prop // don't update            // Part of path, but not object - x
+      : Prop // don't update                // Not part of path - x
+    : never
 } & {}
 
 /** Update in **`O`** the fields at **`Path`** with **`A`**

--- a/tst/Object.ts
+++ b/tst/Object.ts
@@ -1109,6 +1109,27 @@ type OP = { // A binary tree
     c?: string
 };
 
+type OP_UNIONS = {
+    a: {
+        a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }
+    } | 'a'
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }
+    } | 'b'
+    c?: string
+};
+
 // ---------------------------------------------------------------------------------------
 // P.MERGE
 
@@ -1135,8 +1156,32 @@ type O_PMERGE = {
     c?: string
 };
 
+type O_PMERGE_UNIONS = {
+    a: {
+        a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+            x: string
+        }
+    } | 'a'
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }
+        b: {
+            a: 'bba'
+            b: 'bbb'
+            x: string
+        }
+    } | 'b'
+    c?: string
+};
+
 checks([
     check<O.P.Merge<OP, ['a' | 'b', 'b'], {x: string}>, O_PMERGE,  Test.Pass>(),
+    check<O.P.Merge<OP_UNIONS,  ['a' | 'b', 'b'], {x: string}>, O_PMERGE_UNIONS,    Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------
@@ -1158,8 +1203,25 @@ type O_POMIT = {
     c?: string
 };
 
+type O_POMIT_UNIONS = {
+    a: {
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }
+    } | 'a'
+    b?: {
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }
+    } | 'b'
+    c?: string
+};
+
 checks([
     check<O.P.Omit<OP, ['a' | 'b', 'a']>,   O_POMIT,   Test.Pass>(),
+    check<O.P.Omit<OP_UNIONS,   ['a' | 'b', 'a']>,  O_POMIT_UNIONS, Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------
@@ -1179,26 +1241,19 @@ type O_PPICK = {
 
 type O_PPICK_UNIONS = {
     a: {
-        b: string,
-        c: number
-    } | {
-        b: number,
-        d: string
-    } | string
-    e: number
-};
-
-type PPICK_UNIONS_O = {
-    a: {
-        b: string
-    } | {
-        b: number
-    } | string
+        a: string
+    } | 'a'
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }
+    } | 'b'
 };
 
 checks([
     check<O.P.Pick<OP, ['a' | 'b', 'a']>,   O_PPICK,   Test.Pass>(),
-    check<O.P.Pick<O_PPICK_UNIONS, ['a', 'b']>, PPICK_UNIONS_O, Test.Pass>(),
+    check<O.P.Pick<OP_UNIONS,   ['a' | 'b', 'a']>,  O_PPICK_UNIONS, Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------
@@ -1225,8 +1280,30 @@ type O_PREADONLY = {
     c?: string
 };
 
+type O_PREADONLY_UNIONS = {
+    a: {
+        readonly a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }
+    } | 'a'
+    b?: {
+        readonly a: {
+            a: 'baa'
+            b: 'bab'
+        }
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }
+    } | 'b'
+    c?: string
+};
+
 checks([
     check<O.P.Readonly<OP, ['a' | 'b', 'a']>,   O_PREADONLY,   Test.Pass>(),
+    check<O.P.Readonly<OP_UNIONS, ['a' | 'b', 'a']>,    O_PREADONLY_UNIONS, Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------
@@ -1250,6 +1327,25 @@ type O_PUPDATE = {
     c?: string
 };
 
+type O_PUPDATE_UNIONS = {
+    a: {
+        a: 'x'
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }
+    } | 'a'
+    b?: {
+        a: 'x'
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }
+    } | 'b'
+    c?: string
+};
+
 checks([
     check<O.P.Update<OP, ['a' | 'b', 'a'], 'x'>,    O_PUPDATE,     Test.Pass>(),
+    check<O.P.Update<OP_UNIONS, ['a' | 'b', 'a'], 'x'>, O_PUPDATE_UNIONS,   Test.Pass>(),
 ])

--- a/tst/Object.ts
+++ b/tst/Object.ts
@@ -1177,8 +1177,28 @@ type O_PPICK = {
     }
 };
 
+type O_PPICK_UNIONS = {
+    a: {
+        b: string,
+        c: number
+    } | {
+        b: number,
+        d: string
+    } | string
+    e: number
+};
+
+type PPICK_UNIONS_O = {
+    a: {
+        b: string
+    } | {
+        b: number
+    } | string
+};
+
 checks([
     check<O.P.Pick<OP, ['a' | 'b', 'a']>,   O_PPICK,   Test.Pass>(),
+    check<O.P.Pick<O_PPICK_UNIONS, ['a', 'b']>, PPICK_UNIONS_O, Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
## 🎁 Pull Request

<!-- Fill the following checklist. -->
* [x] Used a clear / meaningful title for this pull request
* [ ] Tested the changes in your own code (on your projects)
* [x] Added / Edited tests to reflect changes (`tst` folder)
* [x] Have read the **Contributing** part of the **Readme**
* [x] Passed `npm test`

<!-- Complete the following parts. -->

#### Fixes
<!-- List the issues that this fixes. -->
Having a non-object in a union as a property breaks `O.P.Pick` for any properties in the union.

For example, note how `PartOneAndTwo` incorrectly picks the nested object:

```ts
// {a: 'a'}
type PartOne = O.P.Pick<{a: 'a', b: 'b'}, ['a', 'b']>;
// {a: {b: 'ab'}}
type PartTwo = O.P.Pick<{a: {b: 'ab', c: 'ac'}, b: 'b'}, ['a', 'b']>;
// {a: 'a' | {b: 'ab', c: 'ac'}}
type PartOneAndTwo = O.P.Pick<{a: {b: 'ab', c: 'ac'} | 'a', b: 'b'}, ['a', 'b']>;
```

This PR fixes `PartOneAndTwo` to evaluate to `{a: 'a' | {b: 'ab'}}`.

#### Why have you made changes?
<!-- A clear & concise explanation. -->
To fix the issues above.

#### What changes have you made?
* Added an infer to `O.P.Pick`, making the conditional type distributive. This removes the need to cast `Picked[K]` to an object and distributes `Picked[K]` over all types.

#### What tests have you updated?
* added a new test for `O.P.Pick` in `tst/Object.ts`

#### Is there any breaking changes?
<!-- Fill the following checklist. -->
* [ ] Yes, I changed the public API & documented it
* [ ] Yes, I changed existing tests
* [ ] No,  I added to the public API & documented it
* [x] No,  I added to the existing tests
* [ ] I don't know

#### Anything else worth mentioning?
<!-- Please help with the PR process. -->
<!-- Leave any extra useful information. -->
<!-- Or mention someone who is concerned. -->
Working with advanced types in TypeScript is really fun 😁