### PR TITLE
Simplify all path types to use similar code

### DIFF
--- a/src/Object/P/Merge.ts
+++ b/src/Object/P/Merge.ts
@@ -1,28 +1,26 @@
-import {Merge as OMerge} from '../Merge'
-import {Compute} from '../../Any/Compute'
 import {IterationOf} from '../../Iteration/IterationOf'
 import {Iteration} from '../../Iteration/Iteration'
 import {Pos} from '../../Iteration/Pos'
 import {Next} from '../../Iteration/Next'
 import {Path as PPath} from './_Internal'
 import {Index} from '../../Any/Index'
-import {LastIndex} from '../../Tuple/LastIndex'
-import {Depth} from '../_Internal'
+import {Merge as OMerge} from '../Merge'
+import {Length} from '../../Tuple/Length'
 import {Tuple} from '../../Tuple/Tuple'
 import {Key} from '../../Iteration/Key'
+import {Depth} from '../_Internal'
 
-type _Merge<O extends object, Path extends Tuple<Index>, O1 extends object, depth extends Depth, I extends Iteration = IterationOf<'0'>> = {
-  [K in keyof O]:
-    O[K] extends infer Prop                        // Needed for the below to be distributive
-    ? K extends Path[Pos<I>]                       // If K is part of Path
-      ? Prop extends object                        // & if it's an object
-        ? Key<I> extends LastIndex<Path, 's'>      // & if it's the target
-          ? OMerge<Prop, O1, depth> // merge it    // Update - target
-          : _Merge<Prop, Path, O1, depth, Next<I>> // Or continue diving
-        : Prop                                     // Part of path, but not object - x
-      : Prop                                       // Not part of path - x
-    : never
-} & {}
+type _Merge<O, Path extends Tuple<Index>, O1 extends object, depth extends Depth, I extends Iteration = IterationOf<'0'>> =
+  O extends object                                   // If it's an object
+  ? Key<I> extends Length<Path, 's'>                 // If we've reached the end
+    ? OMerge<O, O1, depth>                           // Use standard Merge
+    : {
+        [K in keyof O]:
+          K extends Path[Pos<I>]                     // If K is part of Path
+            ? _Merge<O[K], Path, O1, depth, Next<I>> // Continue diving
+            : O[K]                                   // Not part of path - x
+      } & {}
+  : O                                                // Not an object - x
 
 /** Complete the fields of **`O`** at **`Path`** with the ones of **`O1`**
  * (⚠️ this type is expensive)

--- a/src/Object/P/Omit.ts
+++ b/src/Object/P/Omit.ts
@@ -4,23 +4,22 @@ import {Pos} from '../../Iteration/Pos'
 import {Next} from '../../Iteration/Next'
 import {Path as PPath} from './_Internal'
 import {Index} from '../../Any/Index'
+import {Omit as OOmit} from '../Omit'
 import {LastIndex} from '../../Tuple/LastIndex'
 import {Tuple} from '../../Tuple/Tuple'
-import {Select} from '../Select'
 import {Key} from '../../Iteration/Key'
 
-type _Omit<O extends object, Path extends Tuple<Index>, I extends Iteration = IterationOf<'0'>> = Select<{                                // No `never` fields
-    [K in keyof O]:
-      O[K] extends infer Prop                 // Needed for the below to be distributive
-      ? K extends Path[Pos<I>]                // If K is part of Path
-        ? Key<I> extends LastIndex<Path, 's'> // & if it's the target
-          ? never // don't pick               // Update - target
-          : Prop extends object               // If it's an object
-            ? _Omit<Prop, Path, Next<I>>      // Continue diving
-            : Prop // pick it                 // Part of path, but not object - x
-        : Prop // pick it                     // Not part of path - x
-      : never
-}, any> & {}
+type _Omit<O, Path extends Tuple<Index>, I extends Iteration = IterationOf<'0'>> =
+  O extends object                       // If it's an object
+  ? Key<I> extends LastIndex<Path, 's'>  // If it's the last index
+    ? OOmit<O, Path[Pos<I>]>             // Use standard Omit
+    : {
+        [K in keyof O]:
+          K extends Path[Pos<I>]         // If K is part of Path
+            ? _Omit<O[K], Path, Next<I>> // Continue diving
+            : O[K]                       // Not part of path - x
+      } & {}
+  : O                                    // Not an object - x
 
 /** Remove out of **`O`** the fields at **`Path`**
  * (⚠️ this type is expensive)

--- a/src/Object/P/Pick.ts
+++ b/src/Object/P/Pick.ts
@@ -9,19 +9,16 @@ import {LastIndex} from '../../Tuple/LastIndex'
 import {Tuple} from '../../Tuple/Tuple'
 import {Key} from '../../Iteration/Key'
 
-type _Pick<O extends object, Path extends Tuple<Index>, I extends Iteration = IterationOf<'0'>> =
-  OPick<O, Path[Pos<I>]> extends infer Picked // Pick the first Path
-  ? {
-      [K in keyof Picked]:
-        Picked[K] extends infer Prop            // Needed for the below to be distributive
-        ? Prop extends object                   // > If it's an object
-          ? Key<I> extends LastIndex<Path, 's'> // & If it's the target
-            ? Prop                              // 1-1: Pick it
-            : _Pick<Prop, Path, Next<I>>        // 1-0: Continue diving
-          : Prop                                // 0: Pick property
-        : never
-    } & {}
-  : never
+type _Pick<O, Path extends Tuple<Index>, I extends Iteration = IterationOf<'0'>> =
+  O extends object                                // If it's an object
+  ? OPick<O, Path[Pos<I>]> extends (infer Picked) // Pick the current index (required for objects with optional keys)
+    ? Key<I> extends LastIndex<Path, 's'>         // If it's the last index
+      ? Picked                                    // Return the picked object
+      : {                                         // Otherwise, continue diving
+          [K in keyof Picked]: _Pick<Picked[K], Path, Next<I>>
+        } & {}
+    : never
+  : O                                             // Not an object - x
 
 /** Extract out of **`O`** the fields at **`Path`**
  * (⚠️ this type is expensive)

--- a/src/Object/P/Readonly.ts
+++ b/src/Object/P/Readonly.ts
@@ -1,32 +1,26 @@
-import {Record} from '../../Object/Record'
-import {Compute} from '../../Any/Compute'
 import {IterationOf} from '../../Iteration/IterationOf'
 import {Iteration} from '../../Iteration/Iteration'
 import {Pos} from '../../Iteration/Pos'
 import {Next} from '../../Iteration/Next'
-import {Readonly as OReadonly} from '../Readonly'
-import {Last} from '../../Tuple/Last'
-import {Pop} from '../../Tuple/Pop'
-import {Depth} from '../_Internal'
 import {Path as PPath} from './_Internal'
-import {Prepend} from '../../Tuple/Prepend'
 import {Index} from '../../Any/Index'
+import {Readonly as OReadonly} from '../Readonly'
 import {LastIndex} from '../../Tuple/LastIndex'
 import {Tuple} from '../../Tuple/Tuple'
 import {Key} from '../../Iteration/Key'
+import {Depth} from '../_Internal'
 
-type _Readonly<O extends object, Path extends Tuple<Index>, K extends Index, depth extends Depth, I extends Iteration = IterationOf<'0'>> = {
-  [P in keyof O]:
-    O[P] extends infer Prop                          // Needed for the below to be distributive
-    ? P extends Path[Pos<I>]                         // If K is part of Path
-      ? Prop extends object                          // & prop is object
-        ? Key<I> extends LastIndex<Path, 's'>        // & if it's the target
-          ? OReadonly<Prop, K, depth> // immutable   // Update - target
-          : _Readonly<Prop, Path, K, depth, Next<I>> // Or continue diving
-        : Prop // don't update                       // Part of path, but not object - x
-      : Prop // don't update                         // Not part of path - x
-    : never
-} & {}
+type _Readonly<O, Path extends Tuple<Index>, depth extends Depth, I extends Iteration = IterationOf<'0'>> =
+  O extends object                                  // If it's an object
+  ? Key<I> extends LastIndex<Path, 's'>             // If it's the last index
+    ? OReadonly<O, Path[Pos<I>], depth>             // Use standard ReadOnly
+    : {
+        [K in keyof O]:
+          K extends Path[Pos<I>]                    // If K is part of Path
+            ? _Readonly<O[K], Path, depth, Next<I>> // Continue diving
+            : O[K]                                  // Not part of path - x
+      } & {}
+  : O                                               // Not an object - x
 
 /** Make some fields of **`O`** readonly at **`Path`** (deeply or not)
  * (⚠️ this type is expensive)
@@ -39,5 +33,4 @@ type _Readonly<O extends object, Path extends Tuple<Index>, K extends Index, dep
  * ```
  */
 export type Readonly<O extends object, Path extends PPath, depth extends Depth = 'flat'> =
-    _Readonly<Record<'_', O>, Pop<Prepend<Path, '_'>>, Last<Path>, depth>['_']
-    // We have nested `O` to be able to perform 0-depth operations as well
+    _Readonly<O, Path, depth>


### PR DESCRIPTION
##  🎁 Pull Request

<!-- Fill the following checklist. -->
* [x] Used a clear / meaningful title for this pull request
* [ ] Tested the changes in your own code (on your projects)
* [ ] Added / Edited tests to reflect changes (`tst` folder)
* [x] Have read the **Contributing** part of the **Readme**
* [x] Passed `npm test`

<!-- Complete the following parts. -->

#### Fixes
<!-- List the issues that this fixes. -->
N/A

#### Why have you made changes?
<!-- A clear & concise explanation. -->
For easier maintenance of code in the future. All path types now have very similar code, so creating / modifying path types should be easier. For example, this will make implementing #57 across all types in **P** significantly easier.

#### What changes have you made?
* simplified all path types to use similar code

#### What tests have you updated?
None.

#### Is there any breaking changes?
No - no tests or public APIs have been changed.

#### Anything else worth mentioning?
<!-- Please help with the PR process. -->
<!-- Leave any extra useful information. -->
<!-- Or mention someone who is concerned. -->

Pick is quite different to the other **P** types, and the code reflects that.