### PR TITLE
feat(o.p): add support for arrays (excluding Update)

### DIFF
--- a/src/Object/P/Merge.ts
+++ b/src/Object/P/Merge.ts
@@ -7,20 +7,40 @@ import {Merge as OMerge} from '../Merge'
 import {Length} from '../../List/Length'
 import {List} from '../../List/List'
 import {Depth} from '../_Internal'
+import {Boolean, False} from '../../Boolean/Boolean'
 
 /**
  * @hidden
  */
-type _Merge<O, Path extends List<Key>, O1 extends object, depth extends Depth, I extends Iteration = IterationOf<'0'>> =
-  O extends object                                               // If it's an object
-  ? Pos<I> extends Length<Path>                                  // If we've reached the end
-    ? OMerge<O, O1, depth>                                       // Use standard Merge
+type MergeObject<O, Path extends List<Key>, O1 extends object, depth extends Depth, I extends Iteration = IterationOf<'0'>> =
+  O extends object                                                    // If it's an object
+  ? Pos<I> extends Length<Path>                                       // If we've reached the end
+    ? OMerge<O, O1, depth>                                            // Use standard Merge
     : {
-        [K in keyof O]: K extends Path[Pos<I>]                   // If K is part of Path
-                        ? _Merge<O[K], Path, O1, depth, Next<I>> // Continue diving
-                        : O[K]                                   // Not part of path - x
+        [K in keyof O]: K extends Path[Pos<I>]                        // If K is part of Path
+                        ? MergeObject<O[K], Path, O1, depth, Next<I>> // Continue diving
+                        : O[K]                                        // Not part of path - x
       } & {}
-  : O                                                            // Not an object - x
+  : O                                                                 // Not an object - x
+
+/**
+ * @hidden
+ */
+type MergeArrays<O, Path extends List<Key>, O1 extends object, depth extends Depth, I extends Iteration = IterationOf<'0'>> =
+  O extends object                              // Same as above, but
+  ? O extends (infer A)[]                       // If O is an array
+    ? {
+        1: MergeArrays<A, Path, O1, depth, I>[] // Dive into the array (TS <3.7)
+        0: never
+      }[O extends any[] ? 1 : 0]
+    : Pos<I> extends Length<Path>
+      ? OMerge<O, O1, depth>
+      : {
+          [K in keyof O]: K extends Path[Pos<I>]
+                          ? MergeArrays<O[K], Path, O1, depth, Next<I>>
+                          : O[K]
+        } & {}
+    : O
 
 /** Complete the fields of **`O`** at **`Path`** with the ones of **`O1`**
  * @param O to complete
@@ -32,5 +52,7 @@ type _Merge<O, Path extends List<Key>, O1 extends object, depth extends Depth, I
  * ```ts
  * ```
  */
-export type Merge<O extends object, Path extends List<Key>, O1 extends object, depth extends Depth = 'flat'> =
-   _Merge<O, Path, O1, depth>
+export type Merge<O extends object, Path extends List<Key>, O1 extends object, depth extends Depth = 'flat', array extends Boolean = False> = {
+  0: MergeObject<O, Path, O1, depth>
+  1: MergeArrays<O, Path, O1, depth>
+}[array]

--- a/src/Object/P/Omit.ts
+++ b/src/Object/P/Omit.ts
@@ -6,20 +6,40 @@ import {Key} from '../../Any/Key'
 import {Omit as OOmit} from '../Omit'
 import {LastIndex} from '../../List/LastIndex'
 import {List} from '../../List/List'
+import {Boolean, False} from '../../Boolean/Boolean'
 
 /**
  * @hidden
  */
-type _Omit<O, Path extends List<Key>, I extends Iteration = IterationOf<'0'>> =
-  O extends object                                   // If it's an object
-  ? Pos<I> extends LastIndex<Path>                   // If it's the last index
-    ? OOmit<O, Path[Pos<I>]>                         // Use standard Omit
+type OmitObject<O, Path extends List<Key>, I extends Iteration = IterationOf<'0'>> =
+  O extends object                                        // If it's an object
+  ? Pos<I> extends LastIndex<Path>                        // If it's the last index
+    ? OOmit<O, Path[Pos<I>]>                              // Use standard Omit
     : {
-        [K in keyof O]: K extends Path[Pos<I>]       // If K is part of Path
-                        ? _Omit<O[K], Path, Next<I>> // Continue diving
-                        : O[K]                       // Not part of path - x
+        [K in keyof O]: K extends Path[Pos<I>]            // If K is part of Path
+                        ? OmitObject<O[K], Path, Next<I>> // Continue diving
+                        : O[K]                            // Not part of path - x
       } & {}
-  : O                                                // Not an object - x
+  : O                                                     // Not an object - x
+
+/**
+ * @hidden
+ */
+type OmitArrays<O, Path extends List<Key>, I extends Iteration = IterationOf<'0'>> =
+  O extends object                  // Same as above, but
+  ? O extends (infer A)[]           // If O is an array
+    ? {
+        1: OmitArrays<A, Path, I>[] // Dive into the array (TS <3.7)
+        0: never
+      }[O extends any[] ? 1 : 0]
+    : Pos<I> extends LastIndex<Path>
+      ? OOmit<O, Path[Pos<I>]>
+      : {
+          [K in keyof O]: K extends Path[Pos<I>]
+                          ? OmitArrays<O[K], Path, Next<I>>
+                          : O[K]
+        } & {}
+  : O
 
 /** Remove out of **`O`** the fields at **`Path`**
  * @param O to remove from
@@ -29,5 +49,7 @@ type _Omit<O, Path extends List<Key>, I extends Iteration = IterationOf<'0'>> =
  * ```ts
  * ```
  */
-export type Omit<O extends object, Path extends List<Key>> =
-    _Omit<O, Path>
+export type Omit<O extends object, Path extends List<Key>, array extends Boolean = False> = {
+  0: OmitObject<O, Path>
+  1: OmitArrays<O, Path>
+}[array]

--- a/src/Object/P/Pick.ts
+++ b/src/Object/P/Pick.ts
@@ -6,20 +6,37 @@ import {Key} from '../../Any/Key'
 import {Pick as OPick} from '../Pick'
 import {LastIndex} from '../../List/LastIndex'
 import {List} from '../../List/List'
+import {Boolean, False} from '../../Boolean/Boolean'
 
 /**
  * @hidden
  */
-type _Pick<O, Path extends List<Key>, I extends Iteration = IterationOf<'0'>> =
+type PickObject<O, Path extends List<Key>, I extends Iteration = IterationOf<'0'>> =
   O extends object                                // If it's an object
   ? OPick<O, Path[Pos<I>]> extends infer Picked   // Pick the current index
     ? Pos<I> extends LastIndex<Path>              // If it's the last index
       ? Picked                                    // Return the picked object
       : {                                         // Otherwise, continue diving
-          [K in keyof Picked]: _Pick<Picked[K], Path, Next<I>>
+          [K in keyof Picked]: PickObject<Picked[K], Path, Next<I>>
         } & {}
     : never
   : O                                             // Not an object - x
+
+type PickArrays<O, Path extends List<Key>, I extends Iteration = IterationOf<'0'>> =
+  O extends object                  // Same as above, but
+  ? O extends (infer A)[]           // If O is an array
+    ? {
+        1: PickArrays<A, Path, I>[] // Dive into the array (TS <3.7)
+        0: never
+      }[O extends any[] ? 1 : 0]
+    : OPick<O, Path[Pos<I>]> extends infer Picked
+      ? Pos<I> extends LastIndex<Path>
+        ? Picked
+        : {
+            [K in keyof Picked]: PickArrays<Picked[K], Path, Next<I>>
+          } & {}
+      : never
+  : O
 
 /** Extract out of **`O`** the fields at **`Path`**
  * @param O to extract from
@@ -29,5 +46,7 @@ type _Pick<O, Path extends List<Key>, I extends Iteration = IterationOf<'0'>> =
  * ```ts
  * ```
  */
-export type Pick<O extends object, Path extends List<Key>> =
-    _Pick<O, Path>
+export type Pick<O extends object, Path extends List<Key>, array extends Boolean = False> = {
+  0: PickObject<O, Path>
+  1: PickArrays<O, Path>
+}[array]

--- a/src/Object/P/Readonly.ts
+++ b/src/Object/P/Readonly.ts
@@ -7,20 +7,40 @@ import {Readonly as OReadonly} from '../Readonly'
 import {LastIndex} from '../../List/LastIndex'
 import {List} from '../../List/List'
 import {Depth} from '../_Internal'
+import {Boolean, False} from '../../Boolean/Boolean'
 
 /**
  * @hidden
  */
-type _Readonly<O, Path extends List<Key>, depth extends Depth, I extends Iteration = IterationOf<'0'>> =
-  O extends object                                              // If it's an object
-  ? Pos<I> extends LastIndex<Path>                              // If it's the last index
-    ? OReadonly<O, Path[Pos<I>], depth>                         // Use standard ReadOnly
+type ReadonlyObject<O, Path extends List<Key>, depth extends Depth, I extends Iteration = IterationOf<'0'>> =
+  O extends object                                                   // If it's an object
+  ? Pos<I> extends LastIndex<Path>                                   // If it's the last index
+    ? OReadonly<O, Path[Pos<I>], depth>                              // Use standard ReadOnly
     : {
-        [K in keyof O]: K extends Path[Pos<I>]                  // If K is part of Path
-                        ? _Readonly<O[K], Path, depth, Next<I>> // Continue diving
-                        : O[K]                                  // Not part of path - x
+        [K in keyof O]: K extends Path[Pos<I>]                       // If K is part of Path
+                        ? ReadonlyObject<O[K], Path, depth, Next<I>> // Continue diving
+                        : O[K]                                       // Not part of path - x
       } & {}
-  : O                                                           // Not an object - x
+  : O                                                                // Not an object - x
+
+/**
+ * @hidden
+ */
+type ReadonlyArrays<O, Path extends List<Key>, depth extends Depth, I extends Iteration = IterationOf<'0'>> =
+  O extends object                             // Same as above, but
+  ? O extends (infer A)[]                      // If O is an array
+    ? {
+        1: ReadonlyArrays<A, Path, depth, I>[] // Dive into the array (TS <3.7)
+        0: never
+      }[O extends any[] ? 1 : 0]
+    : Pos<I> extends LastIndex<Path>
+      ? OReadonly<O, Path[Pos<I>], depth>
+      : {
+          [K in keyof O]: K extends Path[Pos<I>]
+                          ? ReadonlyArrays<O[K], Path, depth, Next<I>>
+                          : O[K]
+        } & {}
+  : O
 
 /** Make some fields of **`O`** readonly at **`Path`** (deeply or not)
  * @param O to make readonly
@@ -31,5 +51,8 @@ type _Readonly<O, Path extends List<Key>, depth extends Depth, I extends Iterati
  * ```ts
  * ```
  */
-export type Readonly<O extends object, Path extends List<Key>, depth extends Depth = 'flat'> =
-    _Readonly<O, Path, depth>
+export type Readonly<O extends object, Path extends List<Key>, depth extends Depth = 'flat', array extends Boolean = False> = {
+  0: ReadonlyObject<O, Path, depth>
+  1: ReadonlyArrays<O, Path, depth>
+}[array]
+

--- a/tst/Object.ts
+++ b/tst/Object.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 
 import {Test, O, A, T} from '../src/index'
-import {False} from '../src/Boolean/Boolean'
+import {True, False} from '../src/Boolean/Boolean'
 
 const {checks, check} = Test
 
@@ -1181,6 +1181,48 @@ type OP_UNIONS = {
     c?: string
 };
 
+type OP_ARRAYS = {
+    a: {
+        a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }[]
+    }[][]
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }[]
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }[]
+    }[]
+    c?: string
+};
+
+type OP_ARRAYS_UNIONS = {
+    a: {
+        a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }[]
+    }[][] | 'a'[]
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }[]
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }[]
+    }[] | 'b'[][]
+    c?: string
+};
+
 // ---------------------------------------------------------------------------------------
 // P.MERGE
 
@@ -1230,9 +1272,59 @@ type O_PMERGE_UNIONS = {
     c?: string
 };
 
+type O_PMERGE_ARRAYS = {
+    a: {
+        a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+            x: string
+        }[]
+    }[][]
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }[]
+        b: {
+            a: 'bba'
+            b: 'bbb'
+            x: string
+        }[]
+    }[]
+    c?: string
+};
+
+type wtf = O.P.Merge<OP_ARRAYS, ['a' | 'b', 'b'], {x: string}, 'flat', True>;
+
+type O_PMERGE_ARRAYS_UNIONS = {
+    a: {
+        a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+            x: string
+        }[]
+    }[][] | 'a'[]
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }[]
+        b: {
+            a: 'bba'
+            b: 'bbb'
+            x: string
+        }[]
+    }[] | 'b'[][]
+    c?: string
+};
+
 checks([
-    check<O.P.Merge<OP, ['a' | 'b', 'b'], {x: string}>,             O_PMERGE,           Test.Pass>(),
-    check<O.P.Merge<OP_UNIONS,  ['a' | 'b', 'b'], {x: string}>,     O_PMERGE_UNIONS,    Test.Pass>(),
+    check<O.P.Merge<OP, ['a' | 'b', 'b'], {x: string}>,                                 O_PMERGE,                   Test.Pass>(),
+    check<O.P.Merge<OP_UNIONS,  ['a' | 'b', 'b'], {x: string}>,                         O_PMERGE_UNIONS,            Test.Pass>(),
+    check<O.P.Merge<OP_ARRAYS,  ['a' | 'b', 'b'], {x: string}, 'flat', True>,           O_PMERGE_ARRAYS,            Test.Pass>(),
+    check<O.P.Merge<OP_ARRAYS_UNIONS,  ['a' | 'b', 'b'], {x: string}, 'flat', True>,    O_PMERGE_ARRAYS_UNIONS,     Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------
@@ -1270,9 +1362,43 @@ type O_POMIT_UNIONS = {
     c?: string
 };
 
+type O_POMIT_ARRAYS = {
+    a: {
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }[]
+    }[][]
+    b?: {
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }[]
+    }[]
+    c?: string
+};
+
+type O_POMIT_ARRAYS_UNIONS = {
+    a: {
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }[]
+    }[][] | 'a'[]
+    b?: {
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }[]
+    }[] | 'b'[][]
+    c?: string
+};
+
 checks([
-    check<O.P.Omit<OP, ['a' | 'b', 'a']>,           O_POMIT,            Test.Pass>(),
-    check<O.P.Omit<OP_UNIONS,   ['a' | 'b', 'a']>,  O_POMIT_UNIONS,     Test.Pass>(),
+    check<O.P.Omit<OP, ['a' | 'b', 'a']>,                           O_POMIT,                Test.Pass>(),
+    check<O.P.Omit<OP_UNIONS,   ['a' | 'b', 'a']>,                  O_POMIT_UNIONS,         Test.Pass>(),
+    check<O.P.Omit<OP_ARRAYS,   ['a' | 'b', 'a'], True>,            O_POMIT_ARRAYS,         Test.Pass>(),
+    check<O.P.Omit<OP_ARRAYS_UNIONS,    ['a' | 'b', 'a'], True>,    O_POMIT_ARRAYS_UNIONS,  Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------
@@ -1302,9 +1428,35 @@ type O_PPICK_UNIONS = {
     } | 'b'
 };
 
+type O_PPICK_ARRAYS = {
+    a: {
+        a: string
+    }[][]
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }[]
+    }[]
+};
+
+type O_PPICK_ARRAYS_UNIONS = {
+    a: {
+        a: string
+    }[][] | 'a'[]
+    b?: {
+        a: {
+            a: 'baa'
+            b: 'bab'
+        }[]
+    }[] | 'b'[][]
+};
+
 checks([
-    check<O.P.Pick<OP, ['a' | 'b', 'a']>,           O_PPICK,            Test.Pass>(),
-    check<O.P.Pick<OP_UNIONS,   ['a' | 'b', 'a']>,  O_PPICK_UNIONS,     Test.Pass>(),
+    check<O.P.Pick<OP, ['a' | 'b', 'a']>,                           O_PPICK,                Test.Pass>(),
+    check<O.P.Pick<OP_UNIONS,   ['a' | 'b', 'a']>,                  O_PPICK_UNIONS,         Test.Pass>(),
+    check<O.P.Pick<OP_ARRAYS,   ['a' | 'b', 'a'], True>,            O_PPICK_ARRAYS,         Test.Pass>(),
+    check<O.P.Pick<OP_ARRAYS_UNIONS,    ['a' | 'b', 'a'], True>,    O_PPICK_ARRAYS_UNIONS,  Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------
@@ -1352,9 +1504,53 @@ type O_PREADONLY_UNIONS = {
     c?: string
 };
 
+type O_PREADONLY_ARRAYS = {
+    a: {
+        readonly a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }[]
+    }[][]
+    b?: {
+        readonly a: {
+            a: 'baa'
+            b: 'bab'
+        }[]
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }[]
+    }[]
+    c?: string
+};
+
+type O_PREADONLY_ARRAYS_UNIONS = {
+    a: {
+        readonly a: string
+        b: {
+            a: 'aba'
+            b: 'abb'
+        }[]
+    }[][] | 'a'[]
+    b?: {
+        readonly a: {
+            a: 'baa'
+            b: 'bab'
+        }[]
+        b: {
+            a: 'bba'
+            b: 'bbb'
+        }[]
+    }[] | 'b'[][]
+    c?: string
+};
+
 checks([
-    check<O.P.Readonly<OP, ['a' | 'b', 'a']>,           O_PREADONLY,            Test.Pass>(),
-    check<O.P.Readonly<OP_UNIONS, ['a' | 'b', 'a']>,    O_PREADONLY_UNIONS,     Test.Pass>(),
+    check<O.P.Readonly<OP, ['a' | 'b', 'a']>,                                   O_PREADONLY,                Test.Pass>(),
+    check<O.P.Readonly<OP_UNIONS,   ['a' | 'b', 'a']>,                          O_PREADONLY_UNIONS,         Test.Pass>(),
+    check<O.P.Readonly<OP_ARRAYS,   ['a' | 'b', 'a'], 'flat', True>,            O_PREADONLY_ARRAYS,         Test.Pass>(),
+    check<O.P.Readonly<OP_ARRAYS_UNIONS,    ['a' | 'b', 'a'], 'flat', True>,    O_PREADONLY_ARRAYS_UNIONS,  Test.Pass>(),
 ])
 
 // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
`O.P.Update` can't be easily updated as it is structured very differently compared to the other `O.P` utility types. It will be significantly refactored when #80 gets merged - that PR will make `O.P.Update` more in line with other `O.P` utility types, so adding array support then will be much easier.

This array functionality is added with an additional "array" boolean parameter to the end of the utility types, which is False by default. As this array functionality is disabled by default this should retain backwards compatibility.

Tests have been added for all utility types modified.

The array functionality was implemented in a way which is compatible with TypeScript versions lower than 3.7.

Closes #57.